### PR TITLE
Introduction of setup_hook to sync commands

### DIFF
--- a/deepfloydif/deepfloydif.py
+++ b/deepfloydif/deepfloydif.py
@@ -14,7 +14,13 @@ from discord.ui import Button, View
 
 HF_TOKEN = os.getenv("HF_TOKEN")
 deepfloydif_client = Client("huggingface-projects/IF", HF_TOKEN)
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+
+# HF GUILD SETTINGS
+# taken from here https://huggingface.co/spaces/huggingface-projects/huggingbots/blob/main/app.py
+MY_GUILD_ID = 1077674588122648679 if os.getenv("TEST_ENV", False) else 879548962464493619
+MY_GUILD = discord.Object(id=MY_GUILD_ID)
+DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN", None)
+
 intents = discord.Intents.all()
 bot = commands.Bot(command_prefix="/", intents=intents)
 
@@ -22,7 +28,10 @@ bot = commands.Bot(command_prefix="/", intents=intents)
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user} (ID: {bot.user.id})")
-    synced = await bot.tree.sync()
+
+async def setup_hook():
+    await bot.wait_until_ready()
+    synced = await bot.tree.sync(guild=discord.Object(MY_GUILD_ID))
     print(f"Synced commands: {', '.join([s.name for s in synced])}.")
     print("------")
 

--- a/falcon180b/falcon180b.py
+++ b/falcon180b/falcon180b.py
@@ -14,6 +14,12 @@ event = Event()
 
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 
+# HF GUILD SETTINGS
+# taken from here https://huggingface.co/spaces/huggingface-projects/huggingbots/blob/main/app.py
+MY_GUILD_ID = 1077674588122648679 if os.getenv("TEST_ENV", False) else 879548962464493619
+MY_GUILD = discord.Object(id=MY_GUILD_ID)
+DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN", None)
+
 
 async def wait(job):
     while not job.done():
@@ -43,9 +49,12 @@ bot = commands.Bot(command_prefix="/", intents=intents)
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user} (ID: {bot.user.id})")
-    synced = await bot.tree.sync()
+    print("------")
+
+async def setup_hook():
+    await bot.wait_until_ready()
+    synced = await bot.tree.sync(guild=discord.Object(MY_GUILD_ID))
     print(f"Synced commands: {', '.join([s.name for s in synced])}.")
-    event.set()
     print("------")
 
 
@@ -111,11 +120,11 @@ async def on_message(message):
             if message.channel.id in thread_to_user:
                 if thread_to_user[message.channel.id] == message.author.id:
                     await continue_chat(message)
-            else:
-                await bot.process_commands(message)
 
     except Exception as e:
         print(f"Error: {e}")
+
+    await bot.process_commands(message)
 
 
 # running in thread

--- a/legacy/musicgen.py
+++ b/legacy/musicgen.py
@@ -13,7 +13,12 @@ import gradio_client as grc
 from gradio_client.utils import QueueError
 
 event = Event()
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+
+# HF GUILD SETTINGS
+# taken from here https://huggingface.co/spaces/huggingface-projects/huggingbots/blob/main/app.py
+MY_GUILD_ID = 1077674588122648679 if os.getenv("TEST_ENV", False) else 879548962464493619
+MY_GUILD = discord.Object(id=MY_GUILD_ID)
+DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN", None)
 
 
 async def wait(job):
@@ -36,9 +41,12 @@ bot = commands.Bot(command_prefix="/", intents=intents)
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user} (ID: {bot.user.id})")
-    synced = await bot.tree.sync()
+    print("------")
+
+async def setup_hook():
+    await bot.wait_until_ready()
+    synced = await bot.tree.sync(guild=discord.Object(MY_GUILD_ID))
     print(f"Synced commands: {', '.join([s.name for s in synced])}.")
-    event.set()
     print("------")
 
 

--- a/wuerstchen/wuerstchen.py
+++ b/wuerstchen/wuerstchen.py
@@ -11,7 +11,12 @@ from gradio_client import Client
 
 HF_TOKEN = os.getenv("HF_TOKEN")
 wuerstchen_client = Client("huggingface-projects/Wuerstchen-duplicate", HF_TOKEN)
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+
+# HF GUILD SETTINGS
+# taken from here https://huggingface.co/spaces/huggingface-projects/huggingbots/blob/main/app.py
+MY_GUILD_ID = 1077674588122648679 if os.getenv("TEST_ENV", False) else 879548962464493619
+MY_GUILD = discord.Object(id=MY_GUILD_ID)
+DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN", None)
 
 
 intents = discord.Intents.all()
@@ -21,7 +26,11 @@ bot = commands.Bot(command_prefix="/", intents=intents)
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user} (ID: {bot.user.id})")
-    synced = await bot.tree.sync()
+    print("------")
+
+async def setup_hook():
+    await bot.wait_until_ready()
+    synced = await bot.tree.sync(guild=discord.Object(MY_GUILD_ID))
     print(f"Synced commands: {', '.join([s.name for s in synced])}.")
     print("------")
 


### PR DESCRIPTION
Since on_ready() can be called multiple times during bot runtime, command tree synchronization should be moved to setup_hook() to ensure it executes only once during initialization.

Reference https://discordpy.readthedocs.io/en/stable/api.html?highlight=setup_hook#discord.Client.setup_hook