### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,10 +4,10 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
         with:
           python-version: 3.11.4
       

--- a/.github/workflows/sync_codellama.yml
+++ b/.github/workflows/sync_codellama.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Sync with Hugging Face (Codellama)
-      uses: nateraw/huggingface-sync-action@v0.0.4
+      uses: nateraw/huggingface-sync-action@c1518d9edf69c7e6beaa8f0c35df06d5952e2cf0  # v0.0.4
       with:
         github_repo_id: huggingface/discord-bots
         huggingface_repo_id: huggingface-projects/codellama-bot


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `ruff.yml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `ruff.yml` | `actions/setup-python` | `v2` | `v2` | `e9aba2c848f5…` |
| `sync_codellama.yml` | `nateraw/huggingface-sync-action` | `v0.0.4` | `v0.0.4` | `c1518d9edf69…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#105